### PR TITLE
icons: fix color for all star types in starred msg

### DIFF
--- a/wa.user.styl
+++ b/wa.user.styl
@@ -810,7 +810,8 @@
         /// Contacts -> Audio message.
         &[data-icon *= 'status-ptt-green'] > svg > path { fill: ac }
         /// Global -> Starred messages.
-        &[data-icon = 'star'], &[data-icon = 'star-in'] {
+        /// Applys to 'star', 'star-in' & 'star-light'
+        &[data-icon *= 'star'] {
             > svg > path {
                 opacity: 1;
                 fill: ac;


### PR DESCRIPTION
use accent color for **all** types of stars in starred msg, including 'star-light' (images/videos/gifs)