### PR TITLE
chat: changed custom background for message bubble

### DIFF
--- a/wa.user.styl
+++ b/wa.user.styl
@@ -33,13 +33,13 @@
     'Right side  ': 'end   ',
 }
 @var checkbox chat_b_l 'Custom background for left message bubble' 0
-@var color b_l_bg 'Left message bubble color' #222730
+@var color b_l_bg 'Left message bubble color' #2C313A
 @var select chat_right 'Right message bubble position' {
     'Left side   ': 'start ',
     'Right side *': 'end   ',
 }
 @var checkbox chat_b_r 'Custom background for right message bubble' 0
-@var color b_r_bg 'Right message bubble color' #1f232a
+@var color b_r_bg 'Right message bubble color' #111317
 
 @var checkbox emoji_t    'Enable transparent emojis' 1
 @var range    emoji_o    'Emoji default opacity' [0.8, 0.0, 1, 0.01]


### PR DESCRIPTION
Change the default color for the `Custom background for right\left message bubble` fields.
This is what caused the confusion of both #76 and #77.
I think it is appropriate to change the default colors to colors that are more different in shades, making it a clear difference.