### PR TITLE
chat: add border to group alerts

### DIFF
--- a/wa.user.styl
+++ b/wa.user.styl
@@ -1669,8 +1669,11 @@
                 }
             }
         }
-        /// Alerts -> Not a group participant.
-        ._26pkE { c: cm }
+        /// Alerts -> Group ('Not a group participant' / 'Only admins can send messages').
+        ._26pkE {
+            c: cm;
+            border-left: 1px solid bd; 
+        }
         /// Reply.
         ._1ebw2 {
             c: 0 0 bg;


### PR DESCRIPTION
Add a border on ALL sides of the alert to make sure that there's a split between the various chats and the selected one displayed on the right side.