### PR TITLE
chat: contacts popup header divider

### DIFF
--- a/wa.user.styl
+++ b/wa.user.styl
@@ -597,7 +597,7 @@
             box-shadow: 0 4px 8px 2px sh;
             ._13HPh { c: fg }
             ._2VDPW { c: 0 0 hl }
-            /// 'Forward message' popout.
+            /// Contacts popup ('Forward message' / Group -> 'Message admins').
             ._1KDYa {
                 c: 0 0 t;
                 header { c: fg 0 hl }
@@ -610,6 +610,9 @@
                         c: 0 0 ac;
                         box-shadow: bsh;
                     }
+                }
+                > header {
+                    border-bottom: 1px solid bd;
                 }
             }
             /// Failed to connect.


### PR DESCRIPTION
Adds a separator to separate the popup header from the search box