### PR TITLE
global: animation only for icons that take action

### DIFF
--- a/wa.user.styl
+++ b/wa.user.styl
@@ -755,7 +755,11 @@
             &[data-icon='status-sticker'],
             &[data-icon='status-document'],
             &[data-icon='recalled-in'],
-            &[data-icon='recalled-out'] {
+            &[data-icon='recalled-out'],
+            &[data-icon='status-check'],
+            &[data-icon='status-dblcheck'],
+            &[data-icon='status-dblcheck-ack'],
+            {
                 > svg > path {
                     fill-opacity: 0.25 i;
                 }

--- a/wa.user.styl
+++ b/wa.user.styl
@@ -741,7 +741,7 @@
                 transition: 0.15s ease;
             }
             /// Animate-ish.
-            &:hover:not([data-icon='muted'):not([data-icon='pinned']) > svg > path {
+            &:hover:not([data-icon='muted']):not([data-icon='pinned']):not([data-icon='status-sticker']):not([data-icon='status-vcard']):not([data-icon='status-image']):not([data-icon='status-video']):not([data-icon='status-gif']):not([data-icon='status-document']) > svg > path {
                 opacity: 1;
                 fill-opacity: 0.9 i;
             }

--- a/wa.user.styl
+++ b/wa.user.styl
@@ -741,25 +741,21 @@
                 transition: 0.15s ease;
             }
             /// Animate-ish.
-            > svg > path {
+            &:hover > svg > path {
                 opacity: 1;
                 fill-opacity: 0.9 i;
             }
             /// Exclude from animating.
-            &[data-icon='muted'],
-            &[data-icon='pinned'],
-            &[data-icon='status-image'],
-            &[data-icon='status-video'],
-            &[data-icon='status-gif'],
-            &[data-icon='status-vcard'],
-            &[data-icon='status-sticker'],
-            &[data-icon='status-document'],
-            &[data-icon='recalled-in'],
-            &[data-icon='recalled-out'],
-            &[data-icon='status-check'],
-            &[data-icon='status-dblcheck'],
-            &[data-icon='status-dblcheck-ack'],
-            {
+            &[data-icon='muted'],           // muted chat
+            &[data-icon='pinned'],          // pinned chat
+            &[data-icon='status-image'],    // image
+            &[data-icon='status-video'],    // video
+            &[data-icon='status-gif'],      // gif
+            &[data-icon='status-vcard'],    // contact
+            &[data-icon='status-sticker'],  // sticker
+            &[data-icon='status-document'], // document
+            &[data-icon='recalled-in'],     // deleted message
+            &[data-icon='recalled-out'] {   // deleted message
                 > svg > path {
                     fill-opacity: 0.25 i;
                 }

--- a/wa.user.styl
+++ b/wa.user.styl
@@ -741,9 +741,24 @@
                 transition: 0.15s ease;
             }
             /// Animate-ish.
-            &:hover:not([data-icon='muted']):not([data-icon='pinned']):not([data-icon='status-sticker']):not([data-icon='status-vcard']):not([data-icon='status-image']):not([data-icon='status-video']):not([data-icon='status-gif']):not([data-icon='status-document']) > svg > path {
+            > svg > path {
                 opacity: 1;
                 fill-opacity: 0.9 i;
+            }
+            /// Exclude from animating.
+            &[data-icon='muted'],
+            &[data-icon='pinned'],
+            &[data-icon='status-image'],
+            &[data-icon='status-video'],
+            &[data-icon='status-gif'],
+            &[data-icon='status-vcard'],
+            &[data-icon='status-sticker'],
+            &[data-icon='status-document'],
+            &[data-icon='recalled-in'],
+            &[data-icon='recalled-out'] {
+                > svg > path {
+                    fill-opacity: 0.25 i;
+                }
             }
         }
         /// Left -> Status icon.

--- a/wa.user.styl
+++ b/wa.user.styl
@@ -1275,6 +1275,12 @@
                     [data-icon = 'x'] { opacity: 0.55 i }
                     &:disabled path { opacity: 0.55 i }
                     path { opacity: 1 i }
+                    
+                    //Animate-ish
+                    &:hover > span > svg > path { 
+                        opacity: 1 i;
+                        fill-opacity: 0.9 i;
+                    }
                 }
             }
             /// Forwarded message.

--- a/wa.user.styl
+++ b/wa.user.styl
@@ -741,7 +741,7 @@
                 transition: 0.15s ease;
             }
             /// Animate-ish.
-            &:hover > svg > path {
+            &:hover:not([data-icon='muted'):not([data-icon='pinned']) > svg > path {
                 opacity: 1;
                 fill-opacity: 0.9 i;
             }


### PR DESCRIPTION
Remove highlighted animation for 'muted' and 'pinned' chat icons