### PR TITLE
chat: contact media tabs visual difference

### DIFF
--- a/wa.user.styl
+++ b/wa.user.styl
@@ -1222,8 +1222,8 @@
         /// Media/Links/Docs -> Content.
         [data-active-tab] {
             border-bottom: 1px solid bd;
-            c: 0 0 t;
-            button {
+            c: 0 0 bg;
+            button:not(.Y1iVg) {
                 c: cm;
                 &:hover { c: 0 0 hl }
                 &._3caqI { c: fg }
@@ -1232,7 +1232,7 @@
             &::before {
                 margin-bottom: -1px;
                 height: 1px;
-                c: 0 0 ac;
+                c: 0 0 blue;
             }
             /// Selected media.
             /._2Ji5m { c: 0 hl }


### PR DESCRIPTION
1. Using the dark color for the tabs background
2. Using the blue color as an underline