### PR TITLE
chat: replies on-hover effect

### DIFF
--- a/wa.user.styl
+++ b/wa.user.styl
@@ -1576,7 +1576,10 @@
                 &._15CAo._3WZEQ { background: none i }
             }
             /// Replies.
-            ._2HTIU { c: 0 0 bg }
+            ._2HTIU {
+                c: 0 0 bg;
+                &:hover { opacity: 0.8 }
+            }
             /// Feat -> Align left bubble.
             if ( chat_left == 'end' ) { align-items: flex-end }
         }
@@ -1618,7 +1621,10 @@
                 &._15CAo._3WZEQ { background: none i }
             }
             /// Replies.
-            ._2HTIU { c: 0 0 bg }
+            ._2HTIU {
+                c: 0 0 bg;
+                &:hover { opacity: 0.8 }
+            }
             /// Feat -> Align right bubble.
             if ( chat_right == 'start' ) { align-items: flex-start }
         }


### PR DESCRIPTION
A hack to have an on-hover animation for replies (quotes)
**Note**: WhatsApp's default styling is using an additional class to override the background. That requires another shade to `dark`, `darker` and `darken`.