### PR TITLE
chat: select msgs mode pseudo-background z-index

### DIFF
--- a/wa.user.styl
+++ b/wa.user.styl
@@ -1356,6 +1356,7 @@
                     /// States.
                     &:hover, &._3Z2tD {
                         c: 0 0 t;
+                        z-index: 0;
                         &::before { c: 0 0 hl }
                     }
                     /// Right -> Fix bg for checkbox button.


### PR DESCRIPTION
Changing the Pseudo-background to appear underneath the message itself.

From:
![image](https://user-images.githubusercontent.com/20738487/73088747-7e8bb100-3edd-11ea-9951-c479f96b49c4.png)

to:
![image](https://user-images.githubusercontent.com/20738487/73088707-6fa4fe80-3edd-11ea-9c1b-90abe3a349d7.png)