### PR TITLE
global: left pane header height setting

### DIFF
--- a/wa.user.styl
+++ b/wa.user.styl
@@ -22,6 +22,11 @@
 @var checkbox chat_b_c   'Enable blurred contacts' 0
 @var checkbox chat_b_img 'Enable blurred images/videos' 0
 
+@var select   app_l_hdr  'Left pane header height' {
+    'Original                    ': 'original      ',
+    'Minimal                    *': 'minimal       ',
+}
+
 @var select   alerts     'Alerts' {
     'Show all                   *': 'show          ',
     'Hide "Allow notifications"  ': 'notifications ',
@@ -1044,10 +1049,13 @@
         > div[class], > span > div[class], > div > div[class] {
             c: 0 0 hl;
             > header {
-                height: unset;
+                c: 0 0 bd;
+                if ( app_l_hdr == 'minimal' ) {
+                    height: unset;
+                    c: 0 0 hl;
+                }
                 min-height: unset i;
                 border-bottom: 1px solid bd;
-                c: 0 0 hl;
                 /// Global -> Reset header text.
                 /._1pYs5:not(#z) {
                     margin: 0;


### PR DESCRIPTION
additional setting to choose the desired height of the left pane header, between 'minimal' and 'original'
'original' will also match the color scheme of the 'default' background