### PR TITLE
global: a setting for avatars border-radius

### DIFF
--- a/wa.user.styl
+++ b/wa.user.styl
@@ -148,7 +148,7 @@
         --app-width : app_width;
 
         --emoji-o   : emoji_o;
-        
+
         --avatar-r  : avatar_r;
 
         --bg-image  : image_url;
@@ -505,8 +505,9 @@
 
     /// Global -> Profile avatar, Chat avatars, New group icon & no-blocked-contacts icon radius.
     ._3BYwr, ._3RWII, ._3p0T6, ._1i7uJ {
-      border-radius: var(--avatar-r) !important;
-      > img { border-radius: var(--avatar-r) !important }
+        rad: var(--avatar-r) i;
+        c: 0 0 bg;
+        > img { rad: var(--avatar-r) i }
     }
 
     /// Global -> Emojis.

--- a/wa.user.styl
+++ b/wa.user.styl
@@ -28,6 +28,8 @@
     'Hide all                    ': 'hide          ',
 }
 
+@var range avatar_r 'Contacts\' avatar radius' [50, 0, 50, 1, '%']
+
 @var select   chat_m_t   'Message tails style' {
     'Default  *': 'default ',
     'Minimal   ': 'minimal ',
@@ -146,6 +148,8 @@
         --app-width : app_width;
 
         --emoji-o   : emoji_o;
+        
+        --avatar-r  : avatar_r;
 
         --bg-image  : image_url;
         --bg-opacity: bg_opacity;
@@ -497,6 +501,12 @@
             /// HACK: Resolve pane gap/border glitches.
             ._2rI9W { margin-right: -1px }
         }
+    }
+
+    /// Global -> Profile avatar, Chat avatars, New group icon & no-blocked-contacts icon radius.
+    ._3BYwr, ._3RWII, ._3p0T6, ._1i7uJ {
+      border-radius: var(--avatar-r) !important;
+      > img { border-radius: var(--avatar-r) !important }
     }
 
     /// Global -> Emojis.

--- a/wa.user.styl
+++ b/wa.user.styl
@@ -508,6 +508,15 @@
         rad: var(--avatar-r) i;
         c: 0 0 bg;
         > img { rad: var(--avatar-r) i }
+        /// Tweak default-user icon.
+        if ( avatar_r != '50%' ) {
+            /[style *= 'height: 49px'], /[style *= 'height: 200px'] {
+                [data-icon = 'default-user'] svg {
+                    margin-top: -4px;
+                    transform: scale(0.8) i;
+                }
+            }
+        }
     }
 
     /// Global -> Emojis.
@@ -1015,8 +1024,6 @@
                 &._3mMX1 { c: 0 0 bd }
                 /// Remove borders.
                 &::after, > div:last-child { border: none }
-                /// Avatar background.
-                /[style *= 'height: 49px'] { c: 0 0 bd }
                 /// Text.
                 > div:last-child {
                     /// Title/timestamp.
@@ -1182,12 +1189,9 @@
     // App -> Right.
     // _1C9rS
     ._7YAGC .copyable-area {
-        /// Avatar.
-        [style *= 'height: 200px'] {
-            c: 0 0 bd;
-            /// Default avatar.
-            ._2EaHs { c: 0 0 hl }
-        }
+        /// Default avatar.
+        [style *= 'height: 200px'] ._2EaHs { c: 0 0 hl }
+        /// Text color.
         ._1drsQ { c: fg }
         ._2IwIk, ._1goQ0 { c: cm }
         /// Buttons.


### PR DESCRIPTION
A new setting which allows the user to select the `border-radius` of the different profile avatars.
***Need to be fixed: the default user/group image so that the background is square