### PR TITLE
fix: remove accent color from unread messages fixing vednoc#131

### DIFF
--- a/wa.user.css
+++ b/wa.user.css
@@ -824,7 +824,7 @@
     fill: var(--accent) !important;
   }
   ._2lSfP[data-icon *= "-dblcheck"]:not(#z) path,
-  ._209Po[data-icon *= "-dblcheck"]:not(#z) path {
+  ._1xtH9[data-icon *= "-dblcheck"]:not(#z) path {
     fill: var(--accent) !important;
   }
   span[class][data-icon *= "check"] path {

--- a/wa.user.styl
+++ b/wa.user.styl
@@ -925,7 +925,7 @@
         /.a5DO0, /._2lSfP {
             span[data-icon *= '-dblcheck'] path { v: ac }
         }
-        /._2lSfP, /._209Po {
+        /._2lSfP, /._1xtH9 {
             &[data-icon *= '-dblcheck']:not(#z) path { v: ac }
         }
         &[data-icon *= 'check'] path { fill-opacity: 1 i }


### PR DESCRIPTION
Quick fix to avoid coloring unread messages with the accent color. Tested in chrome.