### PR TITLE
excluded emojis from feature blurred media (chat_b_img)

### DIFF
--- a/wa.user.styl
+++ b/wa.user.styl
@@ -1626,7 +1626,7 @@ msg += "P.S. CSS can not create clickable links."
         /// Feat -> Blur media.
         if (chat_b_img) {
             /[class *= 'message-'] [style *= 'height'] {
-                img:not([src*='/pp?']) {
+                img:not([src*='/pp?']):not([class*='emoji']){
                     transition: 0.5s ease
                     transition-delay: var(--blur-out)
                     filter: blur(16px) grayscale(100%)


### PR DESCRIPTION
The recent update adds a rule to the "Blur Media" feature, specifically excluding emoji images from being blurred. This change was implemented by adding :not([class*='emoji']) to the CSS selectors. This ensures that while the feature continues to blur other images for privacy or aesthetic reasons, emojis remain clear and unaffected. This enhancement improves user experience by maintaining the clarity and expressiveness of emojis in the interface.
![example](https://github.com/vednoc/dark-whatsapp/assets/73477811/3181e2cf-1459-4d17-87af-02a9b7dfc923)
